### PR TITLE
Specify mock file name

### DIFF
--- a/Teapot.xcodeproj/project.pbxproj
+++ b/Teapot.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		9FED01051E3A4FF6009A54B4 /* Teapot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FED01001E3A4FF6009A54B4 /* Teapot.swift */; };
 		9FED01061E3A4FF6009A54B4 /* Teapot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FED01001E3A4FF6009A54B4 /* Teapot.swift */; };
 		D197B06C934A836E5ACAD940 /* MockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197BA0495D1052C8D29FD8A /* MockTests.swift */; };
+		D197B0D7CB2FEC9B6B4BD7F1 /* overridden.json in Resources */ = {isa = PBXBuildFile; fileRef = D197BCF4092AC0C96E78327E /* overridden.json */; };
 		D197B130B579FEBF404A20F7 /* MockTeapot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197B195CEC87D0FA798B47B /* MockTeapot.swift */; };
 		D197B176D5E1568F54764698 /* MockTeapot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197B195CEC87D0FA798B47B /* MockTeapot.swift */; };
 		D197B2358CF8B04E00973931 /* invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = D197B578CBCD1E73B2CAD236 /* invalid.json */; };
@@ -57,6 +58,7 @@
 		D197B578CBCD1E73B2CAD236 /* invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = invalid.json; sourceTree = "<group>"; };
 		D197B92809E03181E7EF7AA1 /* get.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = get.json; sourceTree = "<group>"; };
 		D197BA0495D1052C8D29FD8A /* MockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTests.swift; sourceTree = "<group>"; };
+		D197BCF4092AC0C96E78327E /* overridden.json */ = {isa = PBXFileReference; fileEncoding = 1; lastKnownFileType = text.json; path = overridden.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +130,7 @@
 				D197BA0495D1052C8D29FD8A /* MockTests.swift */,
 				D197B92809E03181E7EF7AA1 /* get.json */,
 				D197B578CBCD1E73B2CAD236 /* invalid.json */,
+				D197BCF4092AC0C96E78327E /* overridden.json */,
 			);
 			path = TeapotTests;
 			sourceTree = "<group>";
@@ -279,6 +282,7 @@
 				9F7B89741E51E098009C192E /* app-draw-icon.png in Resources */,
 				D197B9D5F301287A537FE091 /* get.json in Resources */,
 				D197B2358CF8B04E00973931 /* invalid.json in Resources */,
+				D197B0D7CB2FEC9B6B4BD7F1 /* overridden.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Teapot/MockTeapot.swift
+++ b/Teapot/MockTeapot.swift
@@ -48,7 +48,7 @@ open class MockTeapot: Teapot {
     ///   - endPoint: the endpoint that needs to get overridden
     ///   - filename: the name of the json file from which you want the data to be returned
     public func overrideEndPoint(_ endPoint: String, withFilename filename: String) {
-        endpointsToOverride[endPoint] = filename
+        self.endpointsToOverride[endPoint] = filename
     }
 
     override func execute(verb _: Verb, path: String, parameters _: RequestParameter? = nil, headerFields _: [String: String]? = nil, timeoutInterval _: TimeInterval = 5.0, allowsCellular _: Bool = true, completion: @escaping ((NetworkResult) -> Void)) {

--- a/Teapot/MockTeapot.swift
+++ b/Teapot/MockTeapot.swift
@@ -8,6 +8,7 @@ open class MockTeapot: Teapot {
     /// The status codes in words to be set as status code
     public enum StatusCode: Int {
         case ok = 200
+        case noContent = 204
         case created = 201
         case unauthorized = 401
         case forbidden = 403
@@ -43,9 +44,10 @@ open class MockTeapot: Teapot {
             let response = HTTPURLResponse(url: URL(string: path)!, statusCode: self.statusCode.rawValue, httpVersion: nil, headerFields: nil)
             let requestParameter = json != nil ? RequestParameter(json!) : nil
 
-            if self.statusCode != .ok {
+            if self.statusCode.rawValue >= 300 {
                 mockedError = TeapotError.invalidResponseStatus
             }
+
             let networkResult = NetworkResult(requestParameter, response!, mockedError)
 
             completion(networkResult)

--- a/Teapot/MockTeapot.swift
+++ b/Teapot/MockTeapot.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// A subclass of Teapot to be used for mocking
 open class MockTeapot: Teapot {
+    // The name of your mock file
+    open var mockFileName: String?
 
     private var currentBundle: Bundle
 
@@ -19,6 +21,7 @@ open class MockTeapot: Teapot {
 
     /// Errors specific to parsing the specified mock file
     public enum MockError: Error {
+        case missingMockFileName(String)
         case missingMockFile(String)
         case invalidMockFile(String)
     }
@@ -55,7 +58,10 @@ open class MockTeapot: Teapot {
     }
 
     func getMockedData(forPath path: String, completion: @escaping (([String: Any]?, Error?) -> Void)) {
-        let resource = (path as NSString).lastPathComponent
+        guard let resource = mockFileName else {
+            completion(nil, MockError.missingMockFileName("please specify the filename of your mock file"))
+            return 
+        }
 
         if let url = currentBundle.url(forResource: resource, withExtension: "json") {
             do {

--- a/Teapot/MockTeapot.swift
+++ b/Teapot/MockTeapot.swift
@@ -40,6 +40,17 @@ open class MockTeapot: Teapot {
         super.init(baseURL: URL(string: "https://mock.base.url.com")!)
     }
 
+    /// overrideEndPoint.
+    /// call this method if you need a call to a certain endpoint to return a specified mock file
+    /// for example when you have a security call to the server that get's called every time you do an APICall
+    ///
+    /// - Parameters:
+    ///   - endPoint: the endpoint tht needs to get overridden
+    ///   - fileName: the name of the json file from which you want the data to be returned
+    public func overrideEndPoint(_ endPoint: String, withFileName fileName: String) {
+        overrideEndpointDictionary[endPoint] = fileName
+    }
+
     override func execute(verb _: Verb, path: String, parameters _: RequestParameter? = nil, headerFields _: [String: String]? = nil, timeoutInterval _: TimeInterval = 5.0, allowsCellular _: Bool = true, completion: @escaping ((NetworkResult) -> Void)) {
         self.getMockedData(forPath: path) { json, error in
             var mockedError = error
@@ -74,9 +85,5 @@ open class MockTeapot: Teapot {
         } else {
             completion(nil, MockError.missingMockFile("\(resource).json"))
         }
-    }
-
-    func overrideEndPoint(_ endPoint: String, withFileName fileName: String) {
-        overrideEndpointDictionary[endPoint] = fileName
     }
 }

--- a/Teapot/MockTeapot.swift
+++ b/Teapot/MockTeapot.swift
@@ -21,10 +21,10 @@ open class MockTeapot: Teapot {
     }
 
     private let currentBundle: Bundle
-    private let resource: String
+    private let mockFilename: String
     private let statusCode: StatusCode
 
-    private var overrideEndpointDictionary = [String: String]()
+    private var endpointsToOverride = [String: String]()
 
     /// Initialiser.
     ///
@@ -32,23 +32,23 @@ open class MockTeapot: Teapot {
     ///   - bundle: the bundle of your test target, where it will search for the mock file
     ///   - mockFileName: the name of the mock file containing the json that will be returned
     ///   - statusCode: the status code for the response to return errors. Default is 200 "ok" 👌
-    public init(bundle: Bundle, mockFileName: String, statusCode: StatusCode = .ok) {
+    public init(bundle: Bundle, mockFilename: String, statusCode: StatusCode = .ok) {
         self.currentBundle = bundle
-        self.resource = mockFileName
+        self.mockFilename = mockFilename
         self.statusCode = statusCode
 
         super.init(baseURL: URL(string: "https://mock.base.url.com")!)
     }
 
     /// overrideEndPoint.
-    /// call this method if you need a call to a certain endpoint to return a specified mock file
+    /// set the filename of the mocked json you want to return for a call to a certain endpoint
     /// for example when you have a security call to the server that get's called every time you do an APICall
     ///
     /// - Parameters:
-    ///   - endPoint: the endpoint tht needs to get overridden
-    ///   - fileName: the name of the json file from which you want the data to be returned
-    public func overrideEndPoint(_ endPoint: String, withFileName fileName: String) {
-        overrideEndpointDictionary[endPoint] = fileName
+    ///   - endPoint: the endpoint that needs to get overridden
+    ///   - filename: the name of the json file from which you want the data to be returned
+    public func overrideEndPoint(_ endPoint: String, withFilename filename: String) {
+        endpointsToOverride[endPoint] = filename
     }
 
     override func execute(verb _: Verb, path: String, parameters _: RequestParameter? = nil, headerFields _: [String: String]? = nil, timeoutInterval _: TimeInterval = 5.0, allowsCellular _: Bool = true, completion: @escaping ((NetworkResult) -> Void)) {
@@ -69,7 +69,7 @@ open class MockTeapot: Teapot {
 
     func getMockedData(forPath path: String, completion: @escaping (([String: Any]?, Error?) -> Void)) {
         let endPoint = (path as NSString).lastPathComponent
-        let resource = overrideEndpointDictionary[endPoint] ?? self.resource
+        let resource = self.endpointsToOverride[endPoint] ?? self.mockFilename
 
         if let url = currentBundle.url(forResource: resource, withExtension: "json") {
             do {

--- a/TeapotTests/MockTests.swift
+++ b/TeapotTests/MockTests.swift
@@ -4,11 +4,11 @@ import XCTest
 class MockTests: XCTestCase {
 
     func testMock() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "get")
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFilename: "get")
 
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {            
-            case .success(let json, let response):
+            case .success(let json, _):
                 XCTAssertEqual(json!.dictionary!["key"] as! String, "value")
             case .failure:
                 XCTFail()
@@ -17,7 +17,7 @@ class MockTests: XCTestCase {
     }
 
     func testMissingMock() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "missing")
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFilename: "missing")
 
         mockedTeapot.get("/missing") { (result: NetworkResult) in
             switch result {
@@ -35,7 +35,7 @@ class MockTests: XCTestCase {
     }
 
     func testInvalidMock() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "invalid")
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFilename: "invalid")
 
         mockedTeapot.get("/invalid") { (result: NetworkResult) in
             switch result {
@@ -53,7 +53,7 @@ class MockTests: XCTestCase {
     }
 
     func testNoContent() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "get", statusCode: .noContent)
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFilename: "get", statusCode: .noContent)
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {
             case .success(_, let response):
@@ -65,7 +65,7 @@ class MockTests: XCTestCase {
     }
 
     func testUnauthorizedError() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "get", statusCode: .unauthorized)
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFilename: "get", statusCode: .unauthorized)
         
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {
@@ -78,8 +78,8 @@ class MockTests: XCTestCase {
     }
 
     func testEndPointOverriding() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "get")
-        mockedTeapot.overrideEndPoint("overridden", withFileName: "overridden")
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFilename: "get")
+        mockedTeapot.overrideEndPoint("overridden", withFilename: "overridden")
 
         mockedTeapot.get("/overridden") { (result: NetworkResult) in
             switch result {

--- a/TeapotTests/MockTests.swift
+++ b/TeapotTests/MockTests.swift
@@ -76,4 +76,19 @@ class MockTests: XCTestCase {
             }
         }
     }
+
+    func testEndPointOverriding() {
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "get")
+        mockedTeapot.overrideEndPoint("overridden", withFileName: "overridden")
+
+        mockedTeapot.get("/overridden") { (result: NetworkResult) in
+            switch result {
+            case .success(let json, _):
+                XCTAssertEqual(json!.dictionary!["overridden"] as! String, "value")
+            case .failure(let error):
+                print(error)
+                XCTFail()
+            }
+        }
+    }
 }

--- a/TeapotTests/MockTests.swift
+++ b/TeapotTests/MockTests.swift
@@ -5,6 +5,8 @@ class MockTests: XCTestCase {
 
     func testMock() {
         let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self))
+        mockedTeapot.mockFileName = "get"
+
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {            
             case .success(let json, let response):
@@ -17,6 +19,8 @@ class MockTests: XCTestCase {
 
     func testMissingMock() {
         let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self))
+        mockedTeapot.mockFileName = "missing"
+
         mockedTeapot.get("/missing") { (result: NetworkResult) in
             switch result {
             case .success:
@@ -34,6 +38,8 @@ class MockTests: XCTestCase {
 
     func testInvalidMock() {
         let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self))
+        mockedTeapot.mockFileName = "invalid"
+
         mockedTeapot.get("/invalid") { (result: NetworkResult) in
             switch result {
             case .success:
@@ -63,6 +69,8 @@ class MockTests: XCTestCase {
 
     func testUnauthorizedError() {
         let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), statusCode: .unauthorized)
+        mockedTeapot.mockFileName = "get"
+        
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {
             case .success:

--- a/TeapotTests/MockTests.swift
+++ b/TeapotTests/MockTests.swift
@@ -49,6 +49,18 @@ class MockTests: XCTestCase {
         }
     }
 
+    func testNoContent() {
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), statusCode: .noContent)
+        mockedTeapot.get("/get") { (result: NetworkResult) in
+            switch result {
+            case .success(_, let response):
+                XCTAssertEqual(response.statusCode, 204)
+            case .failure:
+                XCTFail()
+            }
+        }
+    }
+
     func testUnauthorizedError() {
         let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), statusCode: .unauthorized)
         mockedTeapot.get("/get") { (result: NetworkResult) in

--- a/TeapotTests/MockTests.swift
+++ b/TeapotTests/MockTests.swift
@@ -4,8 +4,7 @@ import XCTest
 class MockTests: XCTestCase {
 
     func testMock() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self))
-        mockedTeapot.mockFileName = "get"
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "get")
 
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {            
@@ -18,8 +17,7 @@ class MockTests: XCTestCase {
     }
 
     func testMissingMock() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self))
-        mockedTeapot.mockFileName = "missing"
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "missing")
 
         mockedTeapot.get("/missing") { (result: NetworkResult) in
             switch result {
@@ -37,8 +35,7 @@ class MockTests: XCTestCase {
     }
 
     func testInvalidMock() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self))
-        mockedTeapot.mockFileName = "invalid"
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "invalid")
 
         mockedTeapot.get("/invalid") { (result: NetworkResult) in
             switch result {
@@ -56,7 +53,7 @@ class MockTests: XCTestCase {
     }
 
     func testNoContent() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), statusCode: .noContent)
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "get", statusCode: .noContent)
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {
             case .success(_, let response):
@@ -68,8 +65,7 @@ class MockTests: XCTestCase {
     }
 
     func testUnauthorizedError() {
-        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), statusCode: .unauthorized)
-        mockedTeapot.mockFileName = "get"
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFileName: "get", statusCode: .unauthorized)
         
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {

--- a/TeapotTests/overridden.json
+++ b/TeapotTests/overridden.json
@@ -1,0 +1,3 @@
+{
+  "overridden": "value"
+}


### PR DESCRIPTION
Changed the MockTeapot to initialising it with a specified mock file name, instead of taking the endpoint of the call. 

This adds more clarity to which files it uses and more flexibility in giving the mock files meaningful names. 

in other words: muchos better!

(This PR incoorporates an added `.noConent` status that was also needed in project using this dependency)