### PR TITLE
Public error properties

### DIFF
--- a/Teapot/TeapotError.swift
+++ b/Teapot/TeapotError.swift
@@ -31,7 +31,7 @@ public struct TeapotError: LocalizedError {
         return TeapotError(withType: .invalidMockFile, errorDescription: errorDescription)
     }
 
-    enum ErrorType {
+    public enum ErrorType {
         case dataTaskError
         case invalidPayload
         case invalidRequestPath
@@ -41,9 +41,9 @@ public struct TeapotError: LocalizedError {
         case invalidMockFile
     }
 
-    let responseStatus: Int?
-    let underlyingError: Error?
-    let type: ErrorType
+    public let responseStatus: Int?
+    public let underlyingError: Error?
+    public let type: ErrorType
 
     public var errorDescription: String
 

--- a/Teapot/TeapotError.swift
+++ b/Teapot/TeapotError.swift
@@ -31,7 +31,7 @@ public struct TeapotError: LocalizedError {
         return TeapotError(withType: .invalidMockFile, errorDescription: errorDescription)
     }
 
-    public enum ErrorType {
+    public enum ErrorType: Int {
         case dataTaskError
         case invalidPayload
         case invalidRequestPath

--- a/Teapot/TeapotError.swift
+++ b/Teapot/TeapotError.swift
@@ -47,7 +47,7 @@ public struct TeapotError: LocalizedError {
 
     public var errorDescription: String
 
-    init(withType type: ErrorType, errorDescription: String, responseStatus: Int? = nil, underlyingError: Error? = nil) {
+    public init(withType type: ErrorType, errorDescription: String, responseStatus: Int? = nil, underlyingError: Error? = nil) {
         self.type = type
         self.errorDescription = errorDescription
         self.responseStatus = responseStatus


### PR DESCRIPTION
I had to make some properties of the `TeapotError` public so to be able to convert a `TeapotError` to a `ToshiError`. 

The initialiser i needed to make public to be able to test the init with teapot error method of the `ToshiError`