### PR TITLE
Improve overriding endpoint when not primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,159 @@ You can replace it with your own file, implementing those keys and set it global
 ```swift
 Teapot.localizationBundle = Bundle.myAppBundle
 ```
+
+## Mocking 
+
+To mock network calls for testing, you can use a `MockTeapot` instead of a standard `Teapot`. This allows you to return the contents of a file when the `MockTeapot` instance is next used. For example: 
+
+```swift
+let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), 
+							  mockFilename: "get")
+```
+
+Will look in the test bundle for a file named `get.json`, and then return its contents whenever the next method is called on the `MockTeapot`: 
+
+```swift
+mockedTeapot.get("/get") { result in
+	// result will be `.success` and the contents of `get.json` are returned
+}
+```
+
+You can also specify the status code you wish to receive back from the `MockTeapot`. This is useful for testing error handling: 
+
+```swift
+let mockedFailingTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), 
+                                     mockFilename: "get", 
+                                     statusCode: .unauthorized)
+                                     
+mockedFailingTeapot.get("/get") { result in
+     // Result will be `.failure` and the response status code will be 401 Unauthorized
+}
+```
+
+### Overriding Specified Endpoints With A Mock
+
+Occasionally, you will need to hit an endpoint such as retrieving a timestamp or an `XSRF` token prior to making your actual call. 
+
+Here is an example of an API which uses a `Teapot` instance to do something like this: 
+
+```swift 
+class API {
+ 
+    static var currentTeapot: Teapot!
+
+    private static func getTimestamp(completion: (_ timestamp: Int?, error: TeapotError?) -> Void) {
+		currentTeapot.get("/timestamp") { result in 
+			switch result {
+			case .success(let _, response): 
+				guard let timestamp = /* something from the response */ else {
+					let timestampParseError = TeapotError(type: .invalidMockFile, 
+					                					  description: "Error parsing timestamp",
+					                					  responseStatus: response.statusCode, 
+					                					  underlyingError: nil)
+					completion(nil, timestampParseError)
+					return
+				}
+				
+				completion(timestamp, nil)
+			case .failure(let _, _, error):
+				let timestampFetchError = TeapotError(type: error.type,
+				                                      description: "Error fetching timestamp",
+				                                      responseStatus: error.responseStatus,
+				                                      underlyingError: error)
+				completion(nil, timestampFetchError) 
+			}
+		}
+    } 
+    
+    static func fetchSecureString(completion: (_ secureString: String?, error: TeapotError?) -> Void) {
+		getTimestamp { timestamp, error in 
+			guard let timestamp = timestamp else {
+    			completion (nil, error)
+    			return 
+    		}    		
+   			let headers = [ "Timestamp" : timestamp ]
+			currentTeapot.get("/something_secure", headerFields: headers) { result in 
+				switch result {
+				case .success(let _, response) { 
+					guard let secureString = /* something from the response */ else {
+						let stringParseError = TeapotError(type: .invalidMockFile,
+						                                   description: "Error parsing secure string",
+						                                   responseStatus: response.statusCode,
+						                                   underlyingError: nil)
+						completion(nil, stringParseError)
+						return 
+					}
+					completion(secureString, nil)
+				case .failure(let _, _, error): {
+					let stringFetchError = TeapotError(type: error.type,
+							    					   description: "Error fetching secure string",
+							    					   responseStatus: error.responseStatus,
+							    					   underlyingError: error)
+					completion(nil, stringFetchError)
+				}
+			}
+		}
+    }
+}
+```
+
+If you wanted to write a test of this API, you'd want to write something like: 
+
+```swift
+func testGettingSecureString() {
+	let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), 
+								  mockFilename: "something_secure")
+	API.teapot = mockedTeapot
+	
+	API.fetchSecureString { secureString, error in 
+		XCTAssertNil(error)
+		XCTAssertNotNil(secureString)
+		XCTAssertEqual(secureString, "expected secure string")
+	}
+}
+```
+
+However, without any changes, this would cause the `timestamp` endpoint to return the contents of `something_secure.json`. This is not what you want, since that would cause an error in the underlying `getTimestamp` method, causing your test to fail. 
+
+This is where overriding comes in - you can specify that data can be returned for a particular endpoint which is not the direct thing being called by your API. Here, the same test is updated to include an override on the `timestamp` endpoint:
+
+```swift
+func testGettingSecureString() {
+	let mockedOverriddenTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), 
+								 			mockFilename: "something_secure")
+	// Tell the mock teapot to return a particular file for a particular endpoint
+	mockedOverriddenTeapot.overrideEndPoint("timestamp", withFilename: "timestamp")	
+	API.teapot = mockedOverriddenTeapot
+	
+	API.fetchSecureString { secureString, error in 
+		XCTAssertNil(error)
+		XCTAssertNotNil(secureString)
+		XCTAssertEqual(secureString, "expected secure string")
+	}
+}
+```
+
+Now, your test will be passing or failing based on what's happening in the bulk of `getSecureString` rather than just the `getTimestamp` bit. 
+
+Note: If you specify both an overridden endpoint and a failure status, that failure status will not be applied to the endpoint you overrode. 
+
+```swift
+func testUnauthorizedTryingToGetSecureString() {
+	let mockedOverriddenFailingTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), 
+				  								   mockFilename: "something_secure",
+				  								   statusCode: .unauthorized)
+	// Tell the mock teapot to return a particular file for a particular endpoint
+	mockedOverriddenTeapot.overrideEndPoint("timestamp", withFilename: "timestamp")	
+	API.teapot = mockedOverriddenTeapot
+
+	API.fetchSecureString { secureString, error in 
+		XCTAssertNil(secureString)
+		XCTAssertNotNil(error)
+		XCTAssertEqual(error?.description, "Error fetching secure string")
+		XCTAssertEqual(error?.responseStatus, 401)
+	}
+}
+```
+
+This allows you to make sure the failure is actually going through the main error handling in `fetchSecureString` rather than just dying as soon as the `timestamp` endpoint is hit. 

--- a/Teapot/MockTeapot.swift
+++ b/Teapot/MockTeapot.swift
@@ -73,7 +73,7 @@ open class MockTeapot: Teapot {
                 } else {
                     completion(nil, TeapotError.invalidMockFile(resource))
                 }
-            } catch let error {
+            } catch {
                 completion(nil, TeapotError.invalidMockFile(resource))
             }
         } else {

--- a/TeapotTests/MockTests.swift
+++ b/TeapotTests/MockTests.swift
@@ -91,4 +91,27 @@ class MockTests: XCTestCase {
             }
         }
     }
+    
+    func testEndpointOverriddingThenHittingOtherEndpointWithError() {
+        let mockedTeapot = MockTeapot(bundle: Bundle(for: MockTests.self), mockFilename: "", statusCode: .internalServerError)
+        mockedTeapot.overrideEndPoint("overridden", withFilename: "overridden")
+        
+        mockedTeapot.get("/overridden") { initialResult in
+            switch initialResult {
+            case .success(let json, _):
+                XCTAssertEqual(json?.dictionary?["overridden"] as? String, "value")
+                mockedTeapot.get("/get") { secondaryResult in
+                    switch secondaryResult {
+                    case .success:
+                        XCTFail("That should not have worked")
+                    case .failure(_, _, let error):
+                        print(error)
+                        XCTAssertEqual(error.responseStatus, 500)
+                    }
+                }
+            case .failure:
+                XCTFail("The overridden endpoint should have worked")
+            }
+        }
+    }
 }

--- a/TeapotTests/MockTests.swift
+++ b/TeapotTests/MockTests.swift
@@ -9,7 +9,7 @@ class MockTests: XCTestCase {
         mockedTeapot.get("/get") { (result: NetworkResult) in
             switch result {            
             case .success(let json, _):
-                XCTAssertEqual(json!.dictionary!["key"] as! String, "value")
+                XCTAssertEqual(json?.dictionary?["key"] as? String, "value")
             case .failure:
                 XCTFail()
             }
@@ -84,7 +84,7 @@ class MockTests: XCTestCase {
         mockedTeapot.get("/overridden") { (result: NetworkResult) in
             switch result {
             case .success(let json, _):
-                XCTAssertEqual(json!.dictionary!["overridden"] as! String, "value")
+                XCTAssertEqual(json?.dictionary?["overridden"] as? String, "value")
             case .failure(let error):
                 print(error)
                 XCTFail()

--- a/TeapotTests/ResponseTests.swift
+++ b/TeapotTests/ResponseTests.swift
@@ -10,7 +10,7 @@ class ResponseTests: XCTestCase {
         XCTAssertNotNil(json.array)
         XCTAssertNotNil(json.data)
         XCTAssertNil(json.dictionary)
-        XCTAssertEqual(json.data!, data)
+        XCTAssertEqual(json.data, data)
     }
 
     func testFromDict() {
@@ -21,7 +21,7 @@ class ResponseTests: XCTestCase {
         XCTAssertNil(json.array)
         XCTAssertNotNil(json.data)
         XCTAssertNotNil(json.dictionary)
-        XCTAssertEqual(json.data!, data)
+        XCTAssertEqual(json.data, data)
     }
 
     func testDictFromData() {
@@ -31,7 +31,7 @@ class ResponseTests: XCTestCase {
         XCTAssertNil(json.array)
         XCTAssertNotNil(json.data)
         XCTAssertNotNil(json.dictionary)
-        XCTAssertEqual(json.data!, data)
+        XCTAssertEqual(json.data, data)
     }
 
     func testArrayFromData() {
@@ -42,8 +42,8 @@ class ResponseTests: XCTestCase {
         XCTAssertNotNil(json.data)
         XCTAssertNotNil(json.array)
         // internal data uses [] for dicts as well as arrays, so:
-        XCTAssertNotEqual(json.data!, data)
+        XCTAssertNotEqual(json.data, data)
         // but length should still match
-        XCTAssertEqual(json.data!.count, data.count)
+        XCTAssertEqual(json.data?.count, data.count)
     }
 }

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -152,13 +152,18 @@ class TeapotTests: XCTestCase {
         Teapot(baseURL: url).get() { (result: NetworkImageResult) in
             switch result {
             case .success(let image, let response):
-                let localImage = Bundle(for: TeapotTests.self).image(forResource: NSImage.Name(rawValue: "app-draw-icon"))!
+                guard let localImage = Bundle(for: TeapotTests.self).image(forResource: NSImage.Name(rawValue: "app-draw-icon")), let tiff = localImage.tiffRepresentation else {
+                    XCTFail("Could not create local image TIFF")
+                    expectation.fulfill()
+                    return
+                }
 
                 XCTAssertEqual(response.statusCode, 200)
-                XCTAssertEqual(image.tiffRepresentation!, localImage.tiffRepresentation!)
+                XCTAssertEqual(image.tiffRepresentation, tiff)
                 expectation.fulfill()
             case .failure(_, _):
-                break
+                XCTFail("Network call for image failed")
+                expectation.fulfill()
             }
         }
 

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -7,12 +7,11 @@ class TeapotTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+
         self.teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!)
     }
     
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         self.teapot = nil
         super.tearDown()
     }
@@ -20,7 +19,6 @@ class TeapotTests: XCTestCase {
     func testGet() {
         let expectation = self.expectation(description: "Get")
 
-        // pass
         self.teapot?.get("/get") { (result: NetworkResult) in
             switch result {
             case .success(let json, let response):
@@ -41,7 +39,6 @@ class TeapotTests: XCTestCase {
     func testPost() {
         let expectation = self.expectation(description: "Post")
 
-        // pass
         self.teapot?.post("/post") { (result) in
 
             switch result {
@@ -63,7 +60,6 @@ class TeapotTests: XCTestCase {
     func testPut() {
         let expectation = self.expectation(description: "Put")
 
-        // pass
         self.teapot?.put("/put") { (result) in
 
             switch result {
@@ -144,8 +140,6 @@ class TeapotTests: XCTestCase {
     }
 
     func testImage() {
-        // http://icons.iconarchive.com 
-        // /icons/martz90/circle/512/app-draw-icon.png
         let expectation = self.expectation(description: "GetImage")
         let url = URL(string: "http://icons.iconarchive.com/icons/martz90/circle/512/app-draw-icon.png")!
 

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -132,7 +132,7 @@ class TeapotTests: XCTestCase {
                     XCTAssertEqual(queryResult, "hello&&world")
                 }
                 break
-            case .failure(let json, let response, _):
+            case .failure:
                 XCTFail()
             }
 

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -146,10 +146,12 @@ class TeapotTests: XCTestCase {
         Teapot(baseURL: url).get() { (result: NetworkImageResult) in
             switch result {
             case .success(let image, let response):
-                guard let localImage = Bundle(for: TeapotTests.self).image(forResource: NSImage.Name(rawValue: "app-draw-icon")), let tiff = localImage.tiffRepresentation else {
-                    XCTFail("Could not create local image TIFF")
-                    expectation.fulfill()
-                    return
+                guard
+                    let localImage = Bundle(for: TeapotTests.self).image(forResource: NSImage.Name(rawValue: "app-draw-icon")),
+                    let tiff = localImage.tiffRepresentation else {
+                        XCTFail("Could not create local image TIFF")
+                        expectation.fulfill()
+                        return
                 }
 
                 XCTAssertEqual(response.statusCode, 200)


### PR DESCRIPTION
a) Cleaned up some code. 
b) The main point of this PR: 

This change is inspired by an issue I saw in code coverage while trying to bump up some coverage with Toshi's tests. 

If you have to hit an underlying endpoint (like Toshi's timestamp endpoint) to hit your target endpoint and pass in a status code, the error you'll get will actually be from the overridden underlying endpoint and not from the main endpoint. This basically means that even though you think you're doing at least some testing of error handling on your target endpoint, you're not - you're only testing the error handling on the overridden underlying endpoint (meaning, you're only testing that the timestamp endpoint handles errors properly, not  the actual thing you're targeting).

This updates behavior so that if an endpoint is overridden using `overrideEndpoint`, that call will still succeed and it is the targeted call which will fail. 

So basically before: 
-  User tries to test `getUsers`, which under the hood calls `getTimestamp`, passing in a failure status code and overriding the `timestamp` endpoint to provide a timestamp. 
- The call fails at `getTimestamp` and is returned with the failure status code. 
- None of the main call executes. 

And now: 
-  User tries to test `getUsers`, which under the hood calls `getTimestamp`, passing in a failure status code and overriding the `timestamp` endpoint to provide a timestamp. 
- The `getTimestamp` call succeeds and proceeds to the main call.
- The failure is then returned through the main call. 

Let me know if y'all would like further clarification on this - i think the code probably does a better job of explaining it than this novella. 😛 
