### PR TITLE
Render invalid response error messages properly

### DIFF
--- a/Teapot/Teapot.swift
+++ b/Teapot/Teapot.swift
@@ -130,8 +130,17 @@ open class Teapot {
                 case .success(let json, let response):
                     // Handle non-2xx status as error.
                     if response.statusCode < 200 || response.statusCode > 299 {
-                        let errorResult = NetworkResult(json, response, TeapotError.invalidResponseStatus(response.statusCode))
-                        completion(errorResult)
+                        // If there is an error sent from backend, its message should be shown
+                        if let errors = json?.dictionary?["errors"] as? [[String: Any]], let error = errors.first, let message = error["message"] as? String {
+
+                            let responseError = TeapotError(withType: .invalidResponseStatus, description: message)
+                            let errorResult = NetworkResult(json, response, responseError)
+                            completion(errorResult)
+                        } else {
+
+                            let errorResult = NetworkResult(json, response, TeapotError.invalidResponseStatus(response.statusCode))
+                            completion(errorResult)
+                        }
                     } else {
                         completion(result)
                     }


### PR DESCRIPTION
In Toshi we miss some important messages if something is wrong:

f.e. we see:
![img_0580](https://user-images.githubusercontent.com/27722554/39558806-11e529a4-4ed5-11e8-8f67-5e6274d41dd6.PNG)

instead of:
![img_0579](https://user-images.githubusercontent.com/27722554/39558805-11a5aa86-4ed5-11e8-91e4-3e188c4b35ef.PNG)

We should check for `errors` field in `json` response if response status code is not desired but result is still in "success" block.