### PR TITLE
Stop decoding and re-encoding JSON data 

### DIFF
--- a/Teapot/RequestParameter.swift
+++ b/Teapot/RequestParameter.swift
@@ -14,8 +14,11 @@ public enum RequestParameter {
 
     public var dictionary: (Dictionary<String, Any>)? {
         switch self {
-        case .dictionary(let d):
-            return d
+        case .dictionary(let dictionary):
+            return dictionary
+        case .data(let data):
+            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else { return nil }
+            return json as? Dictionary<String, Any>
         default:
             return nil
         }
@@ -23,8 +26,11 @@ public enum RequestParameter {
 
     public var array: (Array<Dictionary<String, Any>>)? {
         switch self {
-        case .array(let a):
-            return a
+        case .array(let array):
+            return array
+        case .data(let data):
+            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else { return nil }
+            return json as? Array<Dictionary<String, Any>>
         default:
             return nil
         }
@@ -50,13 +56,6 @@ public enum RequestParameter {
     }
 
     public init(_ data: Data) {
-        let json = try? JSONSerialization.jsonObject(with: data, options: [])
-        if let array = json as? Array<Dictionary<String, Any>> {
-            self = .array(array)
-        } else if let dict = json as? Dictionary<String, Any> {
-            self = .dictionary(dict)
-        } else {
-            self = .data(data)
-        }
+        self = .data(data)
     }
 }

--- a/TeapotTests/ResponseTests.swift
+++ b/TeapotTests/ResponseTests.swift
@@ -2,14 +2,16 @@ import XCTest
 @testable import TeapotMac
 
 class ResponseTests: XCTestCase {
+    
     func testFromArray() {
-        let ary: [[String: Any]] = [["test" : 1]]
-        let data = try! JSONSerialization.data(withJSONObject: ary, options: [])
-        let json = RequestParameter(ary)
+        let array: [[String: Any]] = [["test" : 1]]
+        let data = try! JSONSerialization.data(withJSONObject: array, options: [])
+        let json = RequestParameter(array)
 
-        XCTAssertNotNil(json.array)
-        XCTAssertNotNil(json.data)
         XCTAssertNil(json.dictionary)
+        XCTAssertNotNil(json.array)
+        XCTAssertEqual(json.array?.count, 1)
+        XCTAssertNotNil(json.data)
         XCTAssertEqual(json.data, data)
     }
 
@@ -19,8 +21,10 @@ class ResponseTests: XCTestCase {
         let json = RequestParameter(dict)
 
         XCTAssertNil(json.array)
-        XCTAssertNotNil(json.data)
         XCTAssertNotNil(json.dictionary)
+        XCTAssertEqual(json.dictionary?["test"] as? Int, 1)
+
+        XCTAssertNotNil(json.data)
         XCTAssertEqual(json.data, data)
     }
 
@@ -39,11 +43,11 @@ class ResponseTests: XCTestCase {
         let json = RequestParameter(data)
 
         XCTAssertNil(json.dictionary)
-        XCTAssertNotNil(json.data)
+
         XCTAssertNotNil(json.array)
-        // internal data uses [] for dicts as well as arrays, so:
-        XCTAssertNotEqual(json.data, data)
-        // but length should still match
-        XCTAssertEqual(json.data?.count, data.count)
+        XCTAssertEqual(json.array?.count, 1)
+
+        XCTAssertNotNil(json.data)
+        XCTAssertEqual(json.data, data)
     }
 }

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -101,7 +101,7 @@ class TeapotTests: XCTestCase {
     }
 
     func testQuery() {
-        let expectation = self.expectation(description: "Delete")
+        let expectation = self.expectation(description: "Query")
         self.teapot?.get("/get/?query=\("something")") { (result: NetworkResult) in
 
             switch result {

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -83,7 +83,7 @@ class TeapotTests: XCTestCase {
 
         let dict = "{\"foo\":\"bar\"}"
         guard let jsonData = dict.data(using: .utf8) else {
-            XCTFail("Couldn't incode dic string")
+            XCTFail("Couldn't encode dictionary string")
             return
         }
 

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -57,6 +57,63 @@ class TeapotTests: XCTestCase {
         self.waitForExpectations(timeout: 20.0)
     }
 
+    func testPostWithJSONData() {
+        let expectation = self.expectation(description: "Put with JSON")
+
+        let array = "[{\"foo\":\"bar\"},{\"foo\":\"baz\"}]"
+        guard let jsonData = array.data(using: .utf8) else {
+            XCTFail("Couldn't encode array string")
+            return
+        }
+
+        let param = RequestParameter(jsonData)
+
+        self.teapot?.post("/post", parameters: param) { (result) in
+            defer {
+                expectation.fulfill()
+            }
+
+            switch result {
+            case .success(let json, let response):
+                XCTAssertEqual(response.statusCode, 200)
+
+                guard let returnedData = json else {
+                    XCTFail("No data returned")
+                    return
+                }
+
+                guard let dictionary = returnedData.dictionary else {
+                    XCTFail("Returned data not of expected type")
+                    return
+                }
+
+                // Did HTTPBin get the data we sent in the same format we sent it?
+                guard
+                    let sentBackData = dictionary["data"] as? String,
+                    let encodedSentBack = sentBackData.data(using: .utf8) else {
+                        XCTFail("Sent back data not of expected type")
+                        return
+                }
+
+                XCTAssertEqual(encodedSentBack, jsonData)
+
+                // Did we send this with the appropriate header type?
+                guard let sentHeaders = dictionary["headers"] as? [String: Any] else {
+                    XCTFail("HTTPBin did not send back a copy of the headers it recieved")
+                    return
+                }
+
+                XCTAssertEqual(sentHeaders["Content-Type"] as? String, "application/json")
+            case .failure(_, _, let error):
+                XCTFail("Unexpected error: \(error)")
+            }
+
+            XCTAssertNotNil(result)
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+
     func testPut() {
         let expectation = self.expectation(description: "Put")
 
@@ -133,7 +190,6 @@ class TeapotTests: XCTestCase {
         }
 
         self.waitForExpectations(timeout: 20.0)
-
     }
 
     func testDelete() {

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -24,8 +24,8 @@ class TeapotTests: XCTestCase {
             case .success(let json, let response):
                 XCTAssertEqual(response.statusCode, 200)
                 XCTAssertNotNil(json)
-            case .failure(_, _, _):
-                XCTAssertTrue(false)
+            case .failure(_, _, let error):
+                XCTFail("Unexpected error: \(error)")
             }
 
             XCTAssertNotNil(result)
@@ -45,8 +45,8 @@ class TeapotTests: XCTestCase {
             case .success(let json, let response):
                 XCTAssertEqual(response.statusCode, 200)
                 XCTAssertNotNil(json)
-            case .failure(_, _, _):
-                XCTAssertTrue(false)
+            case .failure(_, _, let error):
+                XCTFail("Unexpected error: \(error)")
             }
 
             XCTAssertNotNil(result)
@@ -66,8 +66,8 @@ class TeapotTests: XCTestCase {
             case .success(let json, let response):
                 XCTAssertEqual(response.statusCode, 200)
                 XCTAssertNotNil(json)
-            case .failure(_, _, _):
-                XCTAssertTrue(false)
+            case .failure(_, _, let error):
+                XCTFail("Unexpected error: \(error)")
             }
 
             XCTAssertNotNil(result)
@@ -88,8 +88,8 @@ class TeapotTests: XCTestCase {
             case .success(let json, let response):
                 XCTAssertEqual(response.statusCode, 200)
                 XCTAssertNotNil(json)
-            case .failure(_, _, _):
-                XCTAssertTrue(false)
+            case .failure(_, _, let error):
+                XCTFail("Unexpected error: \(error)")
             }
 
             XCTAssertNotNil(result)
@@ -128,8 +128,8 @@ class TeapotTests: XCTestCase {
                     XCTAssertEqual(queryResult, "hello&&world")
                 }
                 break
-            case .failure:
-                XCTFail()
+            case .failure(_, _, let error):
+                XCTFail("Unexpected error: \(error)")
             }
 
             XCTAssertNotNil(result)
@@ -157,8 +157,8 @@ class TeapotTests: XCTestCase {
                 XCTAssertEqual(response.statusCode, 200)
                 XCTAssertEqual(image.tiffRepresentation, tiff)
                 expectation.fulfill()
-            case .failure(_, _):
-                XCTFail("Network call for image failed")
+            case .failure(_, let error):
+                XCTFail("Unexpected error: \(error)")
                 expectation.fulfill()
             }
         }

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -78,6 +78,64 @@ class TeapotTests: XCTestCase {
         self.waitForExpectations(timeout: 20.0)
     }
 
+    func testPutWithJSONData() {
+        let expectation = self.expectation(description: "Put with JSON")
+
+        let dict = "{\"foo\":\"bar\"}"
+        guard let jsonData = dict.data(using: .utf8) else {
+            XCTFail("Couldn't incode dic string")
+            return
+        }
+
+        let param = RequestParameter(jsonData)
+
+        self.teapot?.put("/put", parameters: param) { (result) in
+            defer {
+                expectation.fulfill()
+            }
+
+            switch result {
+            case .success(let json, let response):
+                XCTAssertEqual(response.statusCode, 200)
+
+                guard let returnedData = json else {
+                    XCTFail("No data returned")
+                    return
+                }
+
+                guard let dictionary = returnedData.dictionary else {
+                    XCTFail("Returned data not of expected type")
+                    return
+                }
+
+                // Did HTTPBin get the data we sent in the same format we sent it?
+                guard
+                    let sentBackData = dictionary["data"] as? String,
+                    let encodedSentBack = sentBackData.data(using: .utf8) else {
+                    XCTFail("Sent back data not of expected type")
+                    return
+                }
+
+                XCTAssertEqual(encodedSentBack, jsonData)
+
+                // Did we send this with the appropriate header type?
+                guard let sentHeaders = dictionary["headers"] as? [String: Any] else {
+                    XCTFail("HTTPBin did not send back a copy of the headers it recieved")
+                    return
+                }
+
+                XCTAssertEqual(sentHeaders["Content-Type"] as? String, "application/json")
+            case .failure(_, _, let error):
+                XCTFail("Unexpected error: \(error)")
+            }
+
+            XCTAssertNotNil(result)
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+
+    }
+
     func testDelete() {
         let expectation = self.expectation(description: "Delete")
 


### PR DESCRIPTION
Right now, we're decoding and re-encoding raw JSON data when it's passed in to the `RequestParameter` class so it can more easily be validated as JSON or not. The problem with this was revealed in [Toshi #881](https://github.com/toshiapp/toshi-ios-client/pull/881), where the `JSONEncoder` works differently than `JSONSerialization`, causing signature verification to fail. 

With this change, the data is stored directly, but data can be transformed under the hood so that we don't have to adjust any of the code we're using to create the request and automatically set the `Content-Type` header.

I'd like some thoughts on whether this should be a major version: I personally consider this a fix, since decoding and re-encoding JSON data was definitely not behavior I would have expected. However, the existing behavior was at least validated in a test previously, so I think that might be worth calling this 2.0. 