### PR TITLE
Actually return an error when there's no response

### DIFF
--- a/Teapot/Localizable.strings
+++ b/Teapot/Localizable.strings
@@ -1,4 +1,5 @@
 "teapot_data_task_error" = "An error occurred: data task error occurred: %@.";
+"teapot_no_response_received" = "No response received from server.";
 "teapot_invalid_request_path" = "An error occurred: request URL path is invalid.";
 "teapot_missing_image" = "An error occurred: image is missing.";
 "teapot_invalid_response_status" = "An error occurred: request response status reported an issue. Status code: %d.";

--- a/Teapot/Teapot.swift
+++ b/Teapot/Teapot.swift
@@ -243,7 +243,13 @@ open class Teapot {
 
     func runTask(with request: URLRequest, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask {
         let task = self.session.dataTask(with: request) { data, response, error in
-            guard let response = response else { return }
+            guard let response = response else {
+                let teapotError = TeapotError.noResponse(withUnderlyingError: error)
+                let fakeResponse = HTTPURLResponse(url: self.baseURL, statusCode: 400, httpVersion: nil, headerFields: request.allHTTPHeaderFields)!
+                let errorResult = NetworkResult(nil, fakeResponse, teapotError)
+                completion(errorResult)
+                return
+            }
 
             var json: RequestParameter?
             if let data = data, let deserialised = try? JSONSerialization.jsonObject(with: data, options: []) {

--- a/Teapot/Teapot.swift
+++ b/Teapot/Teapot.swift
@@ -252,8 +252,8 @@ open class Teapot {
                 }
 
                 let teapotError = TeapotError.noResponse(withUnderlyingError: error)
-                let fakeResponse = HTTPURLResponse(url: self.baseURL, statusCode: 400, httpVersion: nil, headerFields: request.allHTTPHeaderFields)!
-                let errorResult = NetworkResult(nil, fakeResponse, teapotError)
+                let errorResponse = HTTPURLResponse(url: self.baseURL, statusCode: 400, httpVersion: nil, headerFields: request.allHTTPHeaderFields)!
+                let errorResult = NetworkResult(nil, errorResponse, teapotError)
                 completion(errorResult)
                 return
             }

--- a/Teapot/Teapot.swift
+++ b/Teapot/Teapot.swift
@@ -244,6 +244,13 @@ open class Teapot {
     func runTask(with request: URLRequest, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask {
         let task = self.session.dataTask(with: request) { data, response, error in
             guard let response = response else {
+                if let error = error {
+                    guard (error as NSError).code != NSURLErrorCancelled else {
+                        // This request was cancelled, do not actually fire the completion block.
+                        return
+                    }
+                }
+
                 let teapotError = TeapotError.noResponse(withUnderlyingError: error)
                 let fakeResponse = HTTPURLResponse(url: self.baseURL, statusCode: 400, httpVersion: nil, headerFields: request.allHTTPHeaderFields)!
                 let errorResult = NetworkResult(nil, fakeResponse, teapotError)

--- a/Teapot/Teapot.swift
+++ b/Teapot/Teapot.swift
@@ -255,6 +255,7 @@ open class Teapot {
                 let errorResponse = HTTPURLResponse(url: self.baseURL, statusCode: 400, httpVersion: nil, headerFields: request.allHTTPHeaderFields)!
                 let errorResult = NetworkResult(nil, errorResponse, teapotError)
                 completion(errorResult)
+                
                 return
             }
 

--- a/Teapot/TeapotError.swift
+++ b/Teapot/TeapotError.swift
@@ -37,6 +37,12 @@ public struct TeapotError: Error, CustomStringConvertible {
         return TeapotError(withType: .incorrectHeaders, description: errorDescription)
     }
 
+    static func noResponse(withUnderlyingError error: Error?) -> TeapotError {
+        let errorDescription = String(format: NSLocalizedString("teapot_no_response_received", bundle: Teapot.localizationBundle, comment: ""))
+
+        return TeapotError(withType: .noResponse, description: errorDescription, underlyingError: error)
+    }
+
     public enum ErrorType: Int {
         case dataTaskError
         case invalidPayload
@@ -46,6 +52,7 @@ public struct TeapotError: Error, CustomStringConvertible {
         case missingMockFile
         case invalidMockFile
         case incorrectHeaders
+        case noResponse
     }
 
     public let responseStatus: Int?


### PR DESCRIPTION
We should be propagating errors to the caller so that things without a response, such as failures due to a lack of an internet connection, can be properly handled. 

The only exception to this is when a request has been actively cancelled - at that point, we do not want to fire the completion block, since we've explicitly said "I don't care."