### PR TITLE
Fix overridden requests dying on header check

### DIFF
--- a/Teapot/MockTeapot.swift
+++ b/Teapot/MockTeapot.swift
@@ -76,7 +76,7 @@ open class MockTeapot: Teapot {
     
     override func execute(verb: Teapot.Verb, path: String, parameters: RequestParameter?, headerFields: [String : String]?, timeoutInterval: TimeInterval, allowsCellular: Bool, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask? {
 
-        guard checkHeadersAgainstExpected(headers: headerFields) else {
+        guard checkHeadersAgainstExpected(headers: headerFields, for: path) else {
             let errorResult = NetworkResult(nil, HTTPURLResponse(url: URL(string: path)!, statusCode: 400, httpVersion: nil, headerFields: nil)!, TeapotError.incorrectHeaders(expected: headersToCheckFor, received: headerFields))
             completion(errorResult)
             return nil
@@ -118,7 +118,12 @@ open class MockTeapot: Teapot {
         }
     }
 
-    private func checkHeadersAgainstExpected(headers: [String: String]?) -> Bool {
+    private func checkHeadersAgainstExpected(headers: [String: String]?, for path: String) -> Bool {
+        guard endpointFileNameForPath(path) == nil else {
+            // Don't check headers on overridden endpoints
+            return true
+        }
+
         guard !headersToCheckFor.isEmpty else {
             // nothing to check
             return true

--- a/Teapot/TeapotError.swift
+++ b/Teapot/TeapotError.swift
@@ -69,3 +69,13 @@ public struct TeapotError: Error, CustomStringConvertible {
         self.underlyingError = underlyingError
     }
 }
+
+extension TeapotError: Equatable {
+
+    public static func ==(lhs: TeapotError, rhs: TeapotError) -> Bool {
+        return lhs.type == rhs.type
+            && lhs.description == rhs.description
+            && lhs.responseStatus == rhs.responseStatus
+            && (lhs.underlyingError as NSError?) == (rhs.underlyingError as NSError?)
+    }
+}

--- a/TeapotTests/MockTests.swift
+++ b/TeapotTests/MockTests.swift
@@ -10,8 +10,8 @@ class MockTests: XCTestCase {
             switch result {            
             case .success(let json, _):
                 XCTAssertEqual(json?.dictionary?["key"] as? String, "value")
-            case .failure:
-                XCTFail()
+            case .failure(_, _, let error):
+                XCTFail("Unexpected error getting mock: \(error)")
             }
         }
     }
@@ -28,7 +28,7 @@ class MockTests: XCTestCase {
                     case .missingMockFile:
                         XCTAssertEqual(error.description, "An error occurred: expected mockfile with name: missing.json")
                     default:
-                        XCTFail()
+                        XCTFail("Incorrect error for missing mock: \(error)")
                 }
             }
         }
@@ -46,7 +46,7 @@ class MockTests: XCTestCase {
                 case .invalidMockFile:
                     XCTAssertEqual(error.description, "An error occurred: invalid mockfile with name: invalid.json")
                 default:
-                    XCTFail()
+                    XCTFail("Incorrect error for invalid file: \(error)")
                 }
             }
         }
@@ -59,7 +59,7 @@ class MockTests: XCTestCase {
             case .success(_, let response):
                 XCTAssertEqual(response.statusCode, 204)
             case .failure:
-                XCTFail()
+                XCTFail("Incorrect status code returned for no content")
             }
         }
     }
@@ -86,8 +86,7 @@ class MockTests: XCTestCase {
             case .success(let json, _):
                 XCTAssertEqual(json?.dictionary?["overridden"] as? String, "value")
             case .failure(let error):
-                print(error)
-                XCTFail()
+                XCTFail("Unexpected error overriding endpoint: \(error)")
             }
         }
     }
@@ -151,7 +150,7 @@ class MockTests: XCTestCase {
                 XCTFail("Request suceceeded which should not have!")
             case .failure(_, let response, let error):
                 XCTAssertEqual(response.statusCode, 400)
-                XCTAssertEqual(error.type, .incorrectHeaders)
+                XCTAssertEqual(error, TeapotError.incorrectHeaders(expected: expectedHeaders, received: nil))
             }
         }
     }
@@ -173,7 +172,7 @@ class MockTests: XCTestCase {
                 XCTFail("Request suceceeded which should not have!")
             case .failure(_, let response, let error):
                 XCTAssertEqual(response.statusCode, 400)
-                XCTAssertEqual(error.type, .incorrectHeaders)
+                XCTAssertEqual(error, TeapotError.incorrectHeaders(expected: expectedHeaders, received: wrongHeaders))
             }
         }
     }
@@ -218,7 +217,7 @@ class MockTests: XCTestCase {
                 XCTFail("Request suceceeded which should not have!")
             case .failure(_, let response, let error):
                 XCTAssertEqual(response.statusCode, 400)
-                XCTAssertEqual(error.type, .incorrectHeaders)
+                XCTAssertEqual(error, TeapotError.incorrectHeaders(expected: expectedHeaders, received: wrongHeaders))
             }
         }
 
@@ -240,7 +239,7 @@ class MockTests: XCTestCase {
         let expectedHeaders = [
             "foo": "bar",
             "baz": "foo2",
-            ]
+        ]
 
         mockedTeapot.setExpectedHeaders(expectedHeaders)
 


### PR DESCRIPTION
This is an issue @marijnschilling ran into on Toshi: We'd want to check the headers on the main request, but not on the initial timestamp request. The timestamp request would fail, causing the entire request to fail. 

Now, if an endpoint is overridden, we only check the headers on the primary request, not on the overridden request. 

Also a bit of cleanup on the tests. 