### PR TITLE
Updating the Teapot initialiser to take a delivery queue argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ let basicAuthHeader = teapot.basicAuthenticationHeader(username:  "", password: 
 ```
 
 ### Teapot itself
-Our cutely named Teapot is the wrapper itself. It’s instantiated with a base URL and exposes four main methods: a `get`, a `post`, a `put`, and a `delete` method.
+Our cutely named Teapot is the wrapper itself. It’s instantiated with a base URL and an optional delivery queue (more on that below) and exposes four main methods: a `get`, a `post`, a `put`, and a `delete` method; as well as a `downloadImage` helper method.
 
 ### Example API client
 
@@ -81,6 +81,20 @@ class APIClient {
         }
     }
 }
+```
+
+### Queue management
+By default Teapot will return everything on the main queue. This can be overridden for every call at initialisation time by instantiating it with a new default delivery queue.
+
+```swift
+let teapot = Teapot(baseURL: url, defaultDeliveryQueue: myBackgroundQueue)
+```
+
+Of course some cases call for more complicated approaches, such as having almost every call go through on a background queue, except that one or two that interact with UIKit and needs to go on main. But we don't want the overhead of calling `DispatchQueue.main.async {}` just after having dispatched to the background queue. For such cases we also offer one-time overrides. You can override the delivery queue for a specific call like so:
+
+```swift
+// This will call the results on the main queue, regarless of what default delivery queue is; just this once.
+teapot.get("/get, deliveryQueue: .main) {}
 ```
 
 ### Cancelling, suspending, resuming, and so on…
@@ -132,11 +146,11 @@ Teapot has a simple logger that will log out certain things under the hood. This
 
 The default log level is `.none` - That is, logs will neither be generated nor printed out. 
 
-Other log levels, in ascending order of how much log barf they fill your console with, are: 
+Other log levels, in ascending order of how much log noise they fill your console with, are: 
 
 - `error` - Logs any error which occurs at the `Teapot` level. 
 - `incomingData` - Logs data received from a server
-- `incomingAndOutgoingData` - Logs data both recieved from a server and being sent to a server. 
+- `incomingAndOutgoingData` - Logs data both received from a server and being sent to a server. 
 
 Log levels are ascending: If you set a `logger`'s log level to `incomingData`, both `incomingData` level logs and `error` level logs will print out. 
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ let teapot = Teapot(baseURL: url, defaultDeliveryQueue: myBackgroundQueue)
 Of course some cases call for more complicated approaches, such as having almost every call go through on a background queue, except that one or two that interact with UIKit and needs to go on main. But we don't want the overhead of calling `DispatchQueue.main.async {}` just after having dispatched to the background queue. For such cases we also offer one-time overrides. You can override the delivery queue for a specific call like so:
 
 ```swift
-// This will call the results on the main queue, regarless of what default delivery queue is; just this once.
+// This will call the results on the main queue, regardless of what default delivery queue is; just this once.
 teapot.get("/get, deliveryQueue: .main) {}
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ mockedFailingTeapot.get("/get") { result in
 }
 ```
 
-### Overriding Specified Endpoints With A Mock
+### Overriding specified endpoints with a mock
 
 Occasionally, you will need to hit an endpoint such as retrieving a timestamp or an `XSRF` token prior to making your actual call. 
 

--- a/Teapot.xcodeproj/project.pbxproj
+++ b/Teapot.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		9F2C23631FE8078000644152 /* BasicAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2C23621FE8078000644152 /* BasicAuthTests.swift */; };
 		9F6AE9B11F9767F2009D56C7 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9F6AE9B01F9767F2009D56C7 /* Localizable.strings */; };
 		9F6AE9B21F9767F2009D56C7 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9F6AE9B01F9767F2009D56C7 /* Localizable.strings */; };
+		9F6BA14D21552A0E00B03EA1 /* DeliveryQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6BA14B215529EC00B03EA1 /* DeliveryQueueTests.swift */; };
 		9F7B896F1E51DA62009C192E /* Teapot+Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B896E1E51DA62009C192E /* Teapot+Images.swift */; };
 		9F7B89701E51DCC6009C192E /* Teapot+Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B896E1E51DA62009C192E /* Teapot+Images.swift */; };
 		9F7B89741E51E098009C192E /* app-draw-icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 9F7B89711E51E03C009C192E /* app-draw-icon.png */; };
@@ -59,6 +60,7 @@
 		9F2C235F1FE8034100644152 /* Teapot+BasicAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Teapot+BasicAuth.swift"; sourceTree = "<group>"; };
 		9F2C23621FE8078000644152 /* BasicAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAuthTests.swift; sourceTree = "<group>"; };
 		9F6AE9B01F9767F2009D56C7 /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
+		9F6BA14B215529EC00B03EA1 /* DeliveryQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryQueueTests.swift; sourceTree = "<group>"; };
 		9F7B896E1E51DA62009C192E /* Teapot+Images.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Teapot+Images.swift"; sourceTree = "<group>"; };
 		9F7B89711E51E03C009C192E /* app-draw-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "app-draw-icon.png"; sourceTree = "<group>"; };
 		9FB36EA31E7BE95900DB6F86 /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 			children = (
 				9F7B89711E51E03C009C192E /* app-draw-icon.png */,
 				9F2C23621FE8078000644152 /* BasicAuthTests.swift */,
+				9F6BA14B215529EC00B03EA1 /* DeliveryQueueTests.swift */,
 				D197BA0495D1052C8D29FD8A /* MockTests.swift */,
 				3363877620A08D26009A7B26 /* LoggerTests.swift */,
 				9FB36EA31E7BE95900DB6F86 /* ResponseTests.swift */,
@@ -348,6 +351,7 @@
 				3363877720A08D26009A7B26 /* LoggerTests.swift in Sources */,
 				9FED00D61E3A4EDA009A54B4 /* TeapotTests.swift in Sources */,
 				9FB36EA41E7BE95900DB6F86 /* ResponseTests.swift in Sources */,
+				9F6BA14D21552A0E00B03EA1 /* DeliveryQueueTests.swift in Sources */,
 				9F2C23631FE8078000644152 /* BasicAuthTests.swift in Sources */,
 				D197B06C934A836E5ACAD940 /* MockTests.swift in Sources */,
 			);

--- a/Teapot/MockTeapot.swift
+++ b/Teapot/MockTeapot.swift
@@ -74,7 +74,7 @@ open class MockTeapot: Teapot {
         return self.endpointsToOverride[endPoint]
     }
 
-    override func execute(verb: Teapot.Verb, path: String, parameters: RequestParameter?, headerFields: [String: String]?, timeoutInterval: TimeInterval, allowsCellular: Bool, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask? {
+    override func execute(verb: Teapot.Verb, path: String, parameters: RequestParameter?, headerFields: [String: String]?, timeoutInterval: TimeInterval, allowsCellular: Bool, deliveryQueue: DispatchQueue?, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask? {
         guard self.checkHeadersAgainstExpected(headers: headerFields, for: path) else {
             let errorResult = NetworkResult(nil, HTTPURLResponse(url: URL(string: path)!, statusCode: 400, httpVersion: nil, headerFields: nil)!, TeapotError.incorrectHeaders(expected: headersToCheckFor, received: headerFields))
             completion(errorResult)

--- a/Teapot/Teapot.swift
+++ b/Teapot/Teapot.swift
@@ -61,7 +61,7 @@ open class Teapot {
     ///   - headerFields: A [String: String] dictionary mapping HTTP header field names to values. Defaults to nil.
     ///   - timeoutInterval: How many seconds before the request times out. Defaults to 15.0
     ///   - allowsCellular: a Bool indicating if this request should be allowed to run over cellular network or WLAN only.
-    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue, which itself defaults to the main queue.
+    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue.
     ///   - completion: The completion block, called with a NetworkResult once the request completes, always on main queue.
     /// - Returns: A URLSessionTask, if the request was successfully created, and nil otherwise.
     @discardableResult open func get(_ path: String, headerFields: [String: String]? = nil, timeoutInterval: TimeInterval = 15.0, allowsCellular: Bool = true, deliveryQueue: DispatchQueue? = nil, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask? {
@@ -77,7 +77,7 @@ open class Teapot {
     ///   - headerFields: A [String: String] dictionary mapping HTTP header field names to values. Defaults to nil.
     ///   - timeoutInterval: How many seconds before the request times out. Defaults to 15.0
     ///   - allowsCellular: a Bool indicating if this request should be allowed to run over cellular network or WLAN only.
-    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue, which itself defaults to the main queue.
+    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue.
     ///   - completion: The completion block, called with a NetworkResult once the request completes, always on main queue.
     /// - Returns: A URLSessionTask, if the request was successfully created, and nil otherwise.
     @discardableResult open func post(_ path: String, parameters: RequestParameter? = nil, headerFields: [String: String]? = nil, timeoutInterval: TimeInterval = 15.0, allowsCellular: Bool = true, deliveryQueue: DispatchQueue? = nil, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask? {
@@ -93,7 +93,7 @@ open class Teapot {
     ///   - headerFields: A [String: String] dictionary mapping HTTP header field names to values. Defaults to nil.
     ///   - timeoutInterval: How many seconds before the request times out. Defaults to 15.0
     ///   - allowsCellular: a Bool indicating if this request should be allowed to run over cellular network or WLAN only.
-    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue, which itself defaults to the main queue.
+    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue.
     ///   - completion: The completion block, called with a NetworkResult once the request completes, always on main queue.
     /// - Returns: A URLSessionTask, if the request was successfully created, and nil otherwise.
     @discardableResult open func put(_ path: String, parameters: RequestParameter? = nil, headerFields: [String: String]? = nil, timeoutInterval: TimeInterval = 15.0, allowsCellular: Bool = true, deliveryQueue: DispatchQueue? = nil, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask? {
@@ -109,7 +109,7 @@ open class Teapot {
     ///   - headerFields: A [String: String] dictionary mapping HTTP header field names to values. Defaults to nil.
     ///   - timeoutInterval: How many seconds before the request times out. Defaults to 15.0
     ///   - allowsCellular: a Bool indicating if this request should be allowed to run over cellular network or WLAN only.
-    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue, which itself defaults to the main queue.
+    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue.
     ///   - completion: The completion block, called with a NetworkResult once the request completes.
     /// - Returns: A URLSessionTask, if the request was successfully created, and nil otherwise.
     @discardableResult open func delete(_ path: String, parameters _: RequestParameter? = nil, headerFields: [String: String]? = nil, timeoutInterval: TimeInterval = 15.0, allowsCellular: Bool = true, deliveryQueue: DispatchQueue? = nil, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask? {
@@ -133,7 +133,7 @@ open class Teapot {
     ///   - headerFields: A [String: String] dictionary mapping HTTP header field names to values. Defaults to nil.
     ///   - timeoutInterval: How many seconds before the request times out. Defaults to 15.0. See URLRequest doc for more.
     ///   - allowsCellular: a Bool indicating if this request should be allowed to run over cellular network or WLAN only.
-    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue, which itself defaults to the main queue.
+    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue.
     ///   - completion: The completion block, called with a NetworkResult once the request completes, always on main queue.
     /// - Returns: A URLSessionTask, if the request was successfully created, and nil otherwise.
     func execute(verb: Verb, path: String, parameters: RequestParameter? = nil, headerFields: [String: String]? = nil, timeoutInterval: TimeInterval = 15.0, allowsCellular: Bool = true, deliveryQueue: DispatchQueue?, completion: @escaping ((NetworkResult) -> Void)) -> URLSessionTask? {
@@ -176,7 +176,7 @@ open class Teapot {
     ///   - headerFields: A [String: String] dictionary mapping HTTP header field names to values. Defaults to nil.
     ///   - timeoutInterval: How many seconds before the request times out. Defaults to 15.0. See URLRequest doc for more.
     ///   - allowsCellular: a Bool indicating if this request should be allowed to run over cellular network or WLAN only.
-    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue, which itself defaults to the main queue.
+    ///   - deliveryQueue: a DispatchQueue where the completion block will be called. If none is supplied, uses the Teapot's defaultDeliveryQueue.
     ///   - completion: The completion block, called with a NetworkImageResult once the request completes, always on main queue.
     /// - Returns: A URLSessionTask, if the request was successfully created, and nil otherwise.
     @discardableResult func downloadImage(path: String? = nil, headerFields: [String: String]? = nil, timeoutInterval: TimeInterval = 15.0, allowsCellular: Bool = true, deliveryQueue: DispatchQueue? = nil, completion: @escaping ((NetworkImageResult) -> Void)) -> URLSessionTask? {

--- a/Teapot/Teapot.swift
+++ b/Teapot/Teapot.swift
@@ -178,12 +178,18 @@ open class Teapot {
 
                     if response.statusCode < 200 || response.statusCode > 299 {
                         let errorResult = NetworkImageResult(image, response, TeapotError.invalidResponseStatus(response.statusCode))
-                        completion(errorResult)
+                        self.deliveryQueue.async {
+                            completion(errorResult)
+                        }
                     } else {
-                        completion(result)
+                        self.deliveryQueue.async {
+                            completion(result)
+                        }
                     }
                 default:
-                    completion(result)
+                    self.deliveryQueue.async {
+                        completion(result)
+                    }
                 }
             }
 
@@ -193,7 +199,9 @@ open class Teapot {
             let response = HTTPURLResponse(url: self.baseURL, statusCode: 400, httpVersion: nil, headerFields: headerFields)!
             let result = NetworkImageResult(nil, response, TeapotError.invalidPayload)
 
-            completion(result)
+            self.deliveryQueue.async {
+                completion(result)
+            }
 
             return nil
         }

--- a/TeapotTests/DeliveryQueueTests.swift
+++ b/TeapotTests/DeliveryQueueTests.swift
@@ -16,7 +16,7 @@ class DeliveryQueueTests: XCTestCase {
 
         let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
         let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
-                            deliveryQueue: dispatchQueue)
+                            defaultDeliveryQueue: dispatchQueue)
 
         teapot.get("/get") { result in
             XCTAssertTrue(!Thread.isMainThread)
@@ -35,7 +35,7 @@ class DeliveryQueueTests: XCTestCase {
 
         let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
         let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
-                            deliveryQueue: dispatchQueue)
+                            defaultDeliveryQueue: dispatchQueue)
 
         teapot.post("/post") { result in
             XCTAssertTrue(!Thread.isMainThread)
@@ -54,7 +54,7 @@ class DeliveryQueueTests: XCTestCase {
 
         let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
         let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
-                            deliveryQueue: dispatchQueue)
+                            defaultDeliveryQueue: dispatchQueue)
 
         teapot.put("/put") { result in
             XCTAssertTrue(!Thread.isMainThread)
@@ -73,7 +73,7 @@ class DeliveryQueueTests: XCTestCase {
 
         let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
         let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
-                            deliveryQueue: dispatchQueue)
+                            defaultDeliveryQueue: dispatchQueue)
 
         teapot.delete("/delete") { result in
             XCTAssertTrue(!Thread.isMainThread)
@@ -92,7 +92,7 @@ class DeliveryQueueTests: XCTestCase {
 
         let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
         let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
-                            deliveryQueue: dispatchQueue)
+                            defaultDeliveryQueue: dispatchQueue)
 
         teapot.downloadImage { result in
             XCTAssertTrue(!Thread.isMainThread)

--- a/TeapotTests/DeliveryQueueTests.swift
+++ b/TeapotTests/DeliveryQueueTests.swift
@@ -1,0 +1,189 @@
+//
+//  DeliveryQueueTests.swift
+//  TeapotMac
+//
+//  Created by Igor Ranieri on 21.09.18.
+//  Copyright © 2018 B&B. All rights reserved.
+//
+
+@testable import TeapotMac
+import XCTest
+
+class DeliveryQueueTests: XCTestCase {
+
+    func testDeliveryOnQueueGet() {
+        let expectation = self.expectation(description: "Get")
+
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
+                            deliveryQueue: dispatchQueue)
+
+        teapot.get("/get") { result in
+            XCTAssertTrue(!Thread.isMainThread)
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+
+    func testDeliveryOnQueuePost() {
+        let expectation = self.expectation(description: "Post")
+
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
+                            deliveryQueue: dispatchQueue)
+
+        teapot.post("/post") { result in
+            XCTAssertTrue(!Thread.isMainThread)
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+       self.waitForExpectations(timeout: 20.0)
+    }
+
+    func testDeliveryOnQueuePut() {
+        let expectation = self.expectation(description: "Put")
+
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
+                            deliveryQueue: dispatchQueue)
+
+        teapot.put("/put") { result in
+            XCTAssertTrue(!Thread.isMainThread)
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+
+    func testDeliveryOnQueueDelete() {
+        let expectation = self.expectation(description: "Delete")
+
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
+                            deliveryQueue: dispatchQueue)
+
+        teapot.delete("/delete") { result in
+            XCTAssertTrue(!Thread.isMainThread)
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+
+    func testDeliveryOnQueueImage() {
+        let expectation = self.expectation(description: "Image")
+
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.here")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!,
+                            deliveryQueue: dispatchQueue)
+
+        teapot.downloadImage { result in
+            XCTAssertTrue(!Thread.isMainThread)
+
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+    
+    func testDeliveryOnMain() {
+        let expectation = self.expectation(description: "Get")
+
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!)
+
+        teapot.get("/get") { result in
+            XCTAssertTrue(Thread.isMainThread)
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+
+    func testDeliveryQueueOverrideGet() {
+        let expectation = self.expectation(description: "Override Get")
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.overriden")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!)
+
+        teapot.get("/get", deliveryQueue: dispatchQueue) { result in
+            XCTAssertTrue(!Thread.isMainThread)
+
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+
+    func testDeliveryQueueOverridePost() {
+        let expectation = self.expectation(description: "Override Post")
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.overriden")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!)
+
+        teapot.post("/post", deliveryQueue: dispatchQueue) { result in
+            XCTAssertTrue(!Thread.isMainThread)
+
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+
+    func testDeliveryQueueOverridePut() {
+        let expectation = self.expectation(description: "Override Put")
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.overriden")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!)
+
+        teapot.put("/put", deliveryQueue: dispatchQueue) { result in
+            XCTAssertTrue(!Thread.isMainThread)
+
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+
+    func testDeliveryQueueOverrideDelete() {
+        let expectation = self.expectation(description: "Override Delete")
+        let dispatchQueue = DispatchQueue(label: "dispatch.queue.overriden")
+        let teapot = Teapot(baseURL: URL(string: "https://httpbin.org")!)
+
+        teapot.delete("/delete", deliveryQueue: dispatchQueue) { result in
+            XCTAssertTrue(!Thread.isMainThread)
+
+            let queueLabel = String(cString: __dispatch_queue_get_label(nil), encoding: .utf8)!
+            XCTAssertEqual(dispatchQueue.label, queueLabel)
+
+            expectation.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 20.0)
+    }
+}

--- a/TeapotTests/TeapotTests.swift
+++ b/TeapotTests/TeapotTests.swift
@@ -264,6 +264,7 @@ class TeapotTests: XCTestCase {
                     let tiff = localImage.tiffRepresentation else {
                     XCTFail("Could not create local image TIFF")
                     expectation.fulfill()
+
                     return
                 }
 


### PR DESCRIPTION
Great if your network request callback does not interact with the UI and
you don't want to have it run on the main queue. But also defaulting to
the main queue, so you don't have to constantly call
`DispatchQueue.main.async {}` otherwise.